### PR TITLE
Resolve issue: TypeError: float() argument must be a string or a numb…

### DIFF
--- a/phone_hunter/pipelines.py
+++ b/phone_hunter/pipelines.py
@@ -47,8 +47,9 @@ class FeatureExtractor(object):
                     if val:
                         retval = val
                         break
-        retval = float(retval)
-        return retval / 1024 if filter_ and retval >= 128 else retval
+        if retval is not None:
+            retval = float(retval)
+            return retval / 1024 if filter_ and retval >= 128 else retval
 
     def __score_os__(self, os_string):
         os_string = os_string.lower()


### PR DESCRIPTION
When there is no `keyword` in `segment` then `retval` remain `None` which raise error to convert float.
```
retval = float(retval)
TypeError: float() argument must be a string or a number, not 'NoneType'

```
Here, I just added a filter to check `None` type.
If you think this code is relevant then you may accept my pull request.

**N.B** i'm learning scrapy and taking as example your projects. Your work is too good for learning.

Thanks
Hizbul Bahar
Software Engineer
The Jaxara IT Ltd, Dahak